### PR TITLE
Player accessibility improvements.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"cleanName": "secret-spreadsheet"
 	},
 	"dependencies": {
-		"materia-widget-development-kit": "^2.4.2"
+		"materia-widget-development-kit": "^2.5.2"
 	},
 	"devDependencies": {
 		"@babel/preset-react": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 		"build": "webpack -p",
 		"build-dev": "webpack",
 		"test": "jest",
-		"test-ci": "TZ='America/New_York' CI=true jest --ci --useStderr --coverage --coverageReporters text-summary cobertura"
+		"test-ci": "TZ='America/New_York' CI=true jest --ci --useStderr --coverage --coverageReporters text-summary cobertura",
+		"test-dev": "TZ='America/New_York' jest --verbose --watchAll --coverage --coverageReporters lcov"
 	},
 	"jest": {
 		"coverageReporters": [

--- a/src/__snapshots__/player.test.js.snap
+++ b/src/__snapshots__/player.test.js.snap
@@ -225,7 +225,7 @@ exports[`Player Render with no question 1`] = `
     >
       <div>
         <h2
-          aria-label="Secret Spreadsheet widget instructions. Cells of this spreadsheet have been intentionally hidden. Navigate the spreadsheet and input the hidden data until all cells have been filled. Capitalization and punctuation must be precise to match correctly. Navigate the table using your screen reader's dedicated key bindings, or use the tab key to move between blank cells."
+          aria-label="Secret Spreadsheet widget instructions. Cells of this spreadsheet have been intentionally hidden. Navigate the spreadsheet and input the hidden data until all cells have been filled. Capitalization and punctuation must be precise to match correctly. Navigate the table cells individually using your screen reader's dedicated key bindings, or use the Tab key to move between blank cells."
           tabIndex="0"
         >
           Secret Spreadsheet - How it works:
@@ -261,6 +261,7 @@ exports[`Player Render with no question 1`] = `
     </div>
     <p
       className="instructions"
+      inert="true"
     >
       Input the 
       <span>
@@ -295,6 +296,7 @@ exports[`Player Render with no question 1`] = `
                   id="cell1"
                 >
                   <input
+                    aria-label="This cell is currently blank, please provide a value."
                     autoComplete="off"
                     className="unanswered"
                     id="1-input"
@@ -314,6 +316,7 @@ exports[`Player Render with no question 1`] = `
                   id="cell2"
                 >
                   <input
+                    aria-label="This cell is currently blank, please provide a value."
                     autoComplete="off"
                     className="unanswered"
                     id="2-input"
@@ -345,6 +348,7 @@ exports[`Player Render with no question 1`] = `
          missing cells
       </p>
       <input
+        aria-label="Submit answers."
         className="filled"
         type="submit"
         value="Submit"
@@ -367,7 +371,7 @@ exports[`Player Render with question and body 1`] = `
     >
       <div>
         <h2
-          aria-label="Secret Spreadsheet widget instructions. Cells of this spreadsheet have been intentionally hidden. Navigate the spreadsheet and input the hidden data until all cells have been filled. Capitalization and punctuation must be precise to match correctly. Navigate the table using your screen reader's dedicated key bindings, or use the tab key to move between blank cells."
+          aria-label="Secret Spreadsheet widget instructions. Cells of this spreadsheet have been intentionally hidden. Navigate the spreadsheet and input the hidden data until all cells have been filled. Capitalization and punctuation must be precise to match correctly. Navigate the table cells individually using your screen reader's dedicated key bindings, or use the Tab key to move between blank cells."
           tabIndex="0"
         >
           Secret Spreadsheet - How it works:
@@ -403,6 +407,7 @@ exports[`Player Render with question and body 1`] = `
     </div>
     <p
       className="instructions"
+      inert="true"
     >
       Input the 
       <span>
@@ -437,6 +442,7 @@ exports[`Player Render with question and body 1`] = `
                   id="cell1"
                 >
                   <input
+                    aria-label="This cell is currently blank, please provide a value."
                     autoComplete="off"
                     className="unanswered"
                     id="1-input"
@@ -456,6 +462,7 @@ exports[`Player Render with question and body 1`] = `
                   id="cell2"
                 >
                   <input
+                    aria-label="This cell is currently blank, please provide a value."
                     autoComplete="off"
                     className="unanswered"
                     id="2-input"
@@ -496,6 +503,7 @@ exports[`Player Render with question and body 1`] = `
         View Question
       </p>
       <input
+        aria-label="Submit answers."
         className="filled"
         type="submit"
         value="Submit"
@@ -518,7 +526,7 @@ exports[`Player Render with question and no body 1`] = `
     >
       <div>
         <h2
-          aria-label="Secret Spreadsheet widget instructions. Cells of this spreadsheet have been intentionally hidden. Navigate the spreadsheet and input the hidden data until all cells have been filled. Capitalization and punctuation must be precise to match correctly. Navigate the table using your screen reader's dedicated key bindings, or use the tab key to move between blank cells."
+          aria-label="Secret Spreadsheet widget instructions. Cells of this spreadsheet have been intentionally hidden. Navigate the spreadsheet and input the hidden data until all cells have been filled. Capitalization and punctuation must be precise to match correctly. Navigate the table cells individually using your screen reader's dedicated key bindings, or use the Tab key to move between blank cells."
           tabIndex="0"
         >
           Secret Spreadsheet - How it works:
@@ -554,6 +562,7 @@ exports[`Player Render with question and no body 1`] = `
     </div>
     <p
       className="instructions"
+      inert="true"
     >
       Input the 
       <span>
@@ -588,6 +597,7 @@ exports[`Player Render with question and no body 1`] = `
                   id="cell1"
                 >
                   <input
+                    aria-label="This cell is currently blank, please provide a value."
                     autoComplete="off"
                     className="unanswered"
                     id="1-input"
@@ -607,6 +617,7 @@ exports[`Player Render with question and no body 1`] = `
                   id="cell2"
                 >
                   <input
+                    aria-label="This cell is currently blank, please provide a value."
                     autoComplete="off"
                     className="unanswered"
                     id="2-input"
@@ -647,6 +658,7 @@ exports[`Player Render with question and no body 1`] = `
         View Question
       </p>
       <input
+        aria-label="Submit answers."
         className="filled"
         type="submit"
         value="Submit"
@@ -669,7 +681,7 @@ exports[`Player Render without randomization 1`] = `
     >
       <div>
         <h2
-          aria-label="Secret Spreadsheet widget instructions. Cells of this spreadsheet have been intentionally hidden. Navigate the spreadsheet and input the hidden data until all cells have been filled. Capitalization and punctuation must be precise to match correctly. Navigate the table using your screen reader's dedicated key bindings, or use the tab key to move between blank cells."
+          aria-label="Secret Spreadsheet widget instructions. Cells of this spreadsheet have been intentionally hidden. Navigate the spreadsheet and input the hidden data until all cells have been filled. Capitalization and punctuation must be precise to match correctly. Navigate the table cells individually using your screen reader's dedicated key bindings, or use the Tab key to move between blank cells."
           tabIndex="0"
         >
           Secret Spreadsheet - How it works:
@@ -705,6 +717,7 @@ exports[`Player Render without randomization 1`] = `
     </div>
     <p
       className="instructions"
+      inert="true"
     >
       Input the 
       <span>
@@ -739,6 +752,7 @@ exports[`Player Render without randomization 1`] = `
                   id="cell1"
                 >
                   <input
+                    aria-label="This cell is currently blank, please provide a value."
                     autoComplete="off"
                     className="unanswered"
                     id="1-input"
@@ -758,6 +772,7 @@ exports[`Player Render without randomization 1`] = `
                   id="cell2"
                 >
                   <input
+                    aria-label="This cell is currently blank, please provide a value."
                     autoComplete="off"
                     className="unanswered"
                     id="2-input"
@@ -798,6 +813,7 @@ exports[`Player Render without randomization 1`] = `
         View Question
       </p>
       <input
+        aria-label="Submit answers."
         className="filled"
         type="submit"
         value="Submit"

--- a/src/__snapshots__/player.test.js.snap
+++ b/src/__snapshots__/player.test.js.snap
@@ -224,7 +224,10 @@ exports[`Player Render with no question 1`] = `
       className="popup help"
     >
       <div>
-        <h2>
+        <h2
+          aria-label="Secret Spreadsheet widget instructions. Cells of this spreadsheet have been intentionally hidden. Navigate the spreadsheet and input the hidden data until all cells have been filled. Capitalization and punctuation must be precise to match correctly. Navigate the table using your screen reader's dedicated key bindings, or use the tab key to move between blank cells."
+          tabIndex="0"
+        >
           Secret Spreadsheet - How it works:
         </h2>
         <div>
@@ -248,6 +251,7 @@ exports[`Player Render with no question 1`] = `
         </div>
         <button
           onClick={[Function]}
+          tabIndex="0"
           type="button"
           value="Got it!"
         >
@@ -265,6 +269,7 @@ exports[`Player Render with no question 1`] = `
        to complete the spreadsheet:
     </p>
     <form
+      inert="yes"
       onSubmit={[Function]}
     >
       <div
@@ -290,6 +295,7 @@ exports[`Player Render with no question 1`] = `
                   id="cell1"
                 >
                   <input
+                    autoComplete="off"
                     className="unanswered"
                     id="1-input"
                     onBlur={[Function]}
@@ -308,6 +314,7 @@ exports[`Player Render with no question 1`] = `
                   id="cell2"
                 >
                   <input
+                    autoComplete="off"
                     className="unanswered"
                     id="2-input"
                     onBlur={[Function]}
@@ -359,7 +366,10 @@ exports[`Player Render with question and body 1`] = `
       className="popup help"
     >
       <div>
-        <h2>
+        <h2
+          aria-label="Secret Spreadsheet widget instructions. Cells of this spreadsheet have been intentionally hidden. Navigate the spreadsheet and input the hidden data until all cells have been filled. Capitalization and punctuation must be precise to match correctly. Navigate the table using your screen reader's dedicated key bindings, or use the tab key to move between blank cells."
+          tabIndex="0"
+        >
           Secret Spreadsheet - How it works:
         </h2>
         <div>
@@ -383,6 +393,7 @@ exports[`Player Render with question and body 1`] = `
         </div>
         <button
           onClick={[Function]}
+          tabIndex="0"
           type="button"
           value="Got it!"
         >
@@ -400,6 +411,7 @@ exports[`Player Render with question and body 1`] = `
        to complete the spreadsheet:
     </p>
     <form
+      inert="yes"
       onSubmit={[Function]}
     >
       <div
@@ -425,6 +437,7 @@ exports[`Player Render with question and body 1`] = `
                   id="cell1"
                 >
                   <input
+                    autoComplete="off"
                     className="unanswered"
                     id="1-input"
                     onBlur={[Function]}
@@ -443,6 +456,7 @@ exports[`Player Render with question and body 1`] = `
                   id="cell2"
                 >
                   <input
+                    autoComplete="off"
                     className="unanswered"
                     id="2-input"
                     onBlur={[Function]}
@@ -473,8 +487,11 @@ exports[`Player Render with question and body 1`] = `
          missing cells
       </p>
       <p
+        aria-roledescription="button"
         className="link"
         onClick={[Function]}
+        onKeyUp={[Function]}
+        tabIndex="0"
       >
         View Question
       </p>
@@ -500,7 +517,10 @@ exports[`Player Render with question and no body 1`] = `
       className="popup help"
     >
       <div>
-        <h2>
+        <h2
+          aria-label="Secret Spreadsheet widget instructions. Cells of this spreadsheet have been intentionally hidden. Navigate the spreadsheet and input the hidden data until all cells have been filled. Capitalization and punctuation must be precise to match correctly. Navigate the table using your screen reader's dedicated key bindings, or use the tab key to move between blank cells."
+          tabIndex="0"
+        >
           Secret Spreadsheet - How it works:
         </h2>
         <div>
@@ -524,6 +544,7 @@ exports[`Player Render with question and no body 1`] = `
         </div>
         <button
           onClick={[Function]}
+          tabIndex="0"
           type="button"
           value="Got it!"
         >
@@ -541,6 +562,7 @@ exports[`Player Render with question and no body 1`] = `
        to complete the spreadsheet:
     </p>
     <form
+      inert="yes"
       onSubmit={[Function]}
     >
       <div
@@ -566,6 +588,7 @@ exports[`Player Render with question and no body 1`] = `
                   id="cell1"
                 >
                   <input
+                    autoComplete="off"
                     className="unanswered"
                     id="1-input"
                     onBlur={[Function]}
@@ -584,6 +607,7 @@ exports[`Player Render with question and no body 1`] = `
                   id="cell2"
                 >
                   <input
+                    autoComplete="off"
                     className="unanswered"
                     id="2-input"
                     onBlur={[Function]}
@@ -614,8 +638,11 @@ exports[`Player Render with question and no body 1`] = `
          missing cells
       </p>
       <p
+        aria-roledescription="button"
         className="link"
         onClick={[Function]}
+        onKeyUp={[Function]}
+        tabIndex="0"
       >
         View Question
       </p>
@@ -641,7 +668,10 @@ exports[`Player Render without randomization 1`] = `
       className="popup help"
     >
       <div>
-        <h2>
+        <h2
+          aria-label="Secret Spreadsheet widget instructions. Cells of this spreadsheet have been intentionally hidden. Navigate the spreadsheet and input the hidden data until all cells have been filled. Capitalization and punctuation must be precise to match correctly. Navigate the table using your screen reader's dedicated key bindings, or use the tab key to move between blank cells."
+          tabIndex="0"
+        >
           Secret Spreadsheet - How it works:
         </h2>
         <div>
@@ -665,6 +695,7 @@ exports[`Player Render without randomization 1`] = `
         </div>
         <button
           onClick={[Function]}
+          tabIndex="0"
           type="button"
           value="Got it!"
         >
@@ -682,6 +713,7 @@ exports[`Player Render without randomization 1`] = `
        to complete the spreadsheet:
     </p>
     <form
+      inert="yes"
       onSubmit={[Function]}
     >
       <div
@@ -707,6 +739,7 @@ exports[`Player Render without randomization 1`] = `
                   id="cell1"
                 >
                   <input
+                    autoComplete="off"
                     className="unanswered"
                     id="1-input"
                     onBlur={[Function]}
@@ -725,6 +758,7 @@ exports[`Player Render without randomization 1`] = `
                   id="cell2"
                 >
                   <input
+                    autoComplete="off"
                     className="unanswered"
                     id="2-input"
                     onBlur={[Function]}
@@ -755,8 +789,11 @@ exports[`Player Render without randomization 1`] = `
          missing cells
       </p>
       <p
+        aria-roledescription="button"
         className="link"
         onClick={[Function]}
+        onKeyUp={[Function]}
+        tabIndex="0"
       >
         View Question
       </p>

--- a/src/components/player/__snapshots__/cell.test.js.snap
+++ b/src/components/player/__snapshots__/cell.test.js.snap
@@ -6,6 +6,7 @@ exports[`Cell component Rendered with user input center aligned 1`] = `
   id={1}
 >
   <input
+    autoComplete="off"
     className="unanswered"
     onBlur={[MockFunction]}
     onChange={[Function]}
@@ -22,6 +23,7 @@ exports[`Cell component Rendered with user input left aligned 1`] = `
   id={1}
 >
   <input
+    autoComplete="off"
     className="unanswered"
     onBlur={[MockFunction]}
     onChange={[Function]}

--- a/src/components/player/__snapshots__/cell.test.js.snap
+++ b/src/components/player/__snapshots__/cell.test.js.snap
@@ -6,6 +6,7 @@ exports[`Cell component Rendered with user input center aligned 1`] = `
   id={1}
 >
   <input
+    aria-label="This cell is currently blank, please provide a value."
     autoComplete="off"
     className="unanswered"
     onBlur={[MockFunction]}
@@ -23,6 +24,7 @@ exports[`Cell component Rendered with user input left aligned 1`] = `
   id={1}
 >
   <input
+    aria-label="This cell is currently blank, please provide a value."
     autoComplete="off"
     className="unanswered"
     onBlur={[MockFunction]}

--- a/src/components/player/__snapshots__/popup.test.js.snap
+++ b/src/components/player/__snapshots__/popup.test.js.snap
@@ -5,7 +5,10 @@ exports[`Popup component Is rendered 1`] = `
   className="popup help"
 >
   <div>
-    <h2>
+    <h2
+      aria-label="Secret Spreadsheet widget instructions. Cells of this spreadsheet have been intentionally hidden. Navigate the spreadsheet and input the hidden data until all cells have been filled. Capitalization and punctuation must be precise to match correctly. Navigate the table using your screen reader's dedicated key bindings, or use the tab key to move between blank cells."
+      tabIndex="0"
+    >
       Secret Spreadsheet - How it works:
     </h2>
     <div>
@@ -29,6 +32,7 @@ exports[`Popup component Is rendered 1`] = `
     </div>
     <button
       onClick={[MockFunction]}
+      tabIndex="0"
       type="button"
       value="Got it!"
     >

--- a/src/components/player/__snapshots__/popup.test.js.snap
+++ b/src/components/player/__snapshots__/popup.test.js.snap
@@ -6,7 +6,7 @@ exports[`Popup component Is rendered 1`] = `
 >
   <div>
     <h2
-      aria-label="Secret Spreadsheet widget instructions. Cells of this spreadsheet have been intentionally hidden. Navigate the spreadsheet and input the hidden data until all cells have been filled. Capitalization and punctuation must be precise to match correctly. Navigate the table using your screen reader's dedicated key bindings, or use the tab key to move between blank cells."
+      aria-label="Secret Spreadsheet widget instructions. Cells of this spreadsheet have been intentionally hidden. Navigate the spreadsheet and input the hidden data until all cells have been filled. Capitalization and punctuation must be precise to match correctly. Navigate the table cells individually using your screen reader's dedicated key bindings, or use the Tab key to move between blank cells."
       tabIndex="0"
     >
       Secret Spreadsheet - How it works:

--- a/src/components/player/__snapshots__/question.test.js.snap
+++ b/src/components/player/__snapshots__/question.test.js.snap
@@ -6,7 +6,9 @@ exports[`Question component Is rendered with question body 1`] = `
 >
   <div>
     <p
+      aria-label="Question: Test entry question: Test question body"
       className="mainQuestion"
+      tabIndex="0"
     >
       Test entry question
     </p>
@@ -14,7 +16,9 @@ exports[`Question component Is rendered with question body 1`] = `
       Test question body
     </p>
     <button
+      aria-label="After closing this dialog focus will be automatically moved to the first empty cell in the spreadsheet."
       onClick={[MockFunction]}
+      tabIndex="0"
       type="button"
       value="Next"
     >
@@ -30,12 +34,16 @@ exports[`Question component Is rendered without question body 1`] = `
 >
   <div>
     <p
+      aria-label="Question: Test entry question: "
       className="mainQuestion"
+      tabIndex="0"
     >
       Test entry question
     </p>
     <button
+      aria-label="After closing this dialog focus will be automatically moved to the first empty cell in the spreadsheet."
       onClick={[MockFunction]}
+      tabIndex="0"
       type="button"
       value="Next"
     >

--- a/src/components/player/__snapshots__/table.test.js.snap
+++ b/src/components/player/__snapshots__/table.test.js.snap
@@ -20,6 +20,7 @@ exports[`PlayerTable component Rendered centered, no header, no labels 1`] = `
         id="cell1"
       >
         <input
+          aria-label="This cell is currently blank, please provide a value."
           autoComplete="off"
           className="unanswered"
           id="1-input"
@@ -39,6 +40,7 @@ exports[`PlayerTable component Rendered centered, no header, no labels 1`] = `
         id="cell2"
       >
         <input
+          aria-label="This cell is currently blank, please provide a value."
           autoComplete="off"
           className="unanswered"
           id="2-input"
@@ -66,21 +68,29 @@ exports[`PlayerTable component Rendered centered, no header, with labels 1`] = `
 <table>
   <thead>
     <tr
+      aria-hidden="true"
       id="column-labels"
+      inert="true"
     >
       <th
+        aria-hidden="true"
         className="label skinny"
         id="col-label-0"
+        inert="true"
       />
       <th
+        aria-hidden="true"
         className="label"
         id="col-label-1"
+        inert="true"
       >
         A
       </th>
       <th
+        aria-hidden="true"
         className="label"
         id="col-label-2"
+        inert="true"
       >
         B
       </th>
@@ -91,8 +101,10 @@ exports[`PlayerTable component Rendered centered, no header, with labels 1`] = `
       id="row0"
     >
       <td
+        aria-hidden="true"
         className="label skinny"
         id="row-label-1"
+        inert="true"
       >
         1
       </td>
@@ -109,6 +121,7 @@ exports[`PlayerTable component Rendered centered, no header, with labels 1`] = `
         id="cell1"
       >
         <input
+          aria-label="This cell is currently blank, please provide a value."
           autoComplete="off"
           className="unanswered"
           id="1-input"
@@ -124,8 +137,10 @@ exports[`PlayerTable component Rendered centered, no header, with labels 1`] = `
       id="row1"
     >
       <td
+        aria-hidden="true"
         className="label skinny"
         id="row-label-2"
+        inert="true"
       >
         2
       </td>
@@ -134,6 +149,7 @@ exports[`PlayerTable component Rendered centered, no header, with labels 1`] = `
         id="cell2"
       >
         <input
+          aria-label="This cell is currently blank, please provide a value."
           autoComplete="off"
           className="unanswered"
           id="2-input"
@@ -186,6 +202,7 @@ exports[`PlayerTable component Rendered centered, with header, no labels 1`] = `
         id="cell2"
       >
         <input
+          aria-label="This cell is currently blank, please provide a value."
           autoComplete="off"
           className="unanswered"
           id="2-input"
@@ -213,21 +230,29 @@ exports[`PlayerTable component Rendered centered, with header, with labels 1`] =
 <table>
   <thead>
     <tr
+      aria-hidden="true"
       id="column-labels"
+      inert="true"
     >
       <th
+        aria-hidden="true"
         className="label skinny"
         id="col-label-0"
+        inert="true"
       />
       <th
+        aria-hidden="true"
         className="label"
         id="col-label-1"
+        inert="true"
       >
         A
       </th>
       <th
+        aria-hidden="true"
         className="label"
         id="col-label-2"
+        inert="true"
       >
         B
       </th>
@@ -236,8 +261,10 @@ exports[`PlayerTable component Rendered centered, with header, with labels 1`] =
       id="row0"
     >
       <th
+        aria-hidden="true"
         className="label skinny"
         id="row-label-1"
+        inert="true"
       >
         1
       </th>
@@ -260,8 +287,10 @@ exports[`PlayerTable component Rendered centered, with header, with labels 1`] =
       id="row1"
     >
       <td
+        aria-hidden="true"
         className="label skinny"
         id="row-label-2"
+        inert="true"
       >
         2
       </td>
@@ -270,6 +299,7 @@ exports[`PlayerTable component Rendered centered, with header, with labels 1`] =
         id="cell2"
       >
         <input
+          aria-label="This cell is currently blank, please provide a value."
           autoComplete="off"
           className="unanswered"
           id="2-input"
@@ -313,6 +343,7 @@ exports[`PlayerTable component Rendered leftAligned, no header, no labels 1`] = 
         id="cell1"
       >
         <input
+          aria-label="This cell is currently blank, please provide a value."
           autoComplete="off"
           className="unanswered"
           id="1-input"
@@ -332,6 +363,7 @@ exports[`PlayerTable component Rendered leftAligned, no header, no labels 1`] = 
         id="cell2"
       >
         <input
+          aria-label="This cell is currently blank, please provide a value."
           autoComplete="off"
           className="unanswered"
           id="2-input"
@@ -359,21 +391,29 @@ exports[`PlayerTable component Rendered leftAligned, no header, with labels 1`] 
 <table>
   <thead>
     <tr
+      aria-hidden="true"
       id="column-labels"
+      inert="true"
     >
       <th
+        aria-hidden="true"
         className="label skinny"
         id="col-label-0"
+        inert="true"
       />
       <th
+        aria-hidden="true"
         className="label"
         id="col-label-1"
+        inert="true"
       >
         A
       </th>
       <th
+        aria-hidden="true"
         className="label"
         id="col-label-2"
+        inert="true"
       >
         B
       </th>
@@ -384,8 +424,10 @@ exports[`PlayerTable component Rendered leftAligned, no header, with labels 1`] 
       id="row0"
     >
       <td
+        aria-hidden="true"
         className="label skinny"
         id="row-label-1"
+        inert="true"
       >
         1
       </td>
@@ -402,6 +444,7 @@ exports[`PlayerTable component Rendered leftAligned, no header, with labels 1`] 
         id="cell1"
       >
         <input
+          aria-label="This cell is currently blank, please provide a value."
           autoComplete="off"
           className="unanswered"
           id="1-input"
@@ -417,8 +460,10 @@ exports[`PlayerTable component Rendered leftAligned, no header, with labels 1`] 
       id="row1"
     >
       <td
+        aria-hidden="true"
         className="label skinny"
         id="row-label-2"
+        inert="true"
       >
         2
       </td>
@@ -427,6 +472,7 @@ exports[`PlayerTable component Rendered leftAligned, no header, with labels 1`] 
         id="cell2"
       >
         <input
+          aria-label="This cell is currently blank, please provide a value."
           autoComplete="off"
           className="unanswered"
           id="2-input"
@@ -479,6 +525,7 @@ exports[`PlayerTable component Rendered leftAligned, with header, no labels 1`] 
         id="cell2"
       >
         <input
+          aria-label="This cell is currently blank, please provide a value."
           autoComplete="off"
           className="unanswered"
           id="2-input"
@@ -506,21 +553,29 @@ exports[`PlayerTable component Rendered leftAligned, with header, with labels 1`
 <table>
   <thead>
     <tr
+      aria-hidden="true"
       id="column-labels"
+      inert="true"
     >
       <th
+        aria-hidden="true"
         className="label skinny"
         id="col-label-0"
+        inert="true"
       />
       <th
+        aria-hidden="true"
         className="label"
         id="col-label-1"
+        inert="true"
       >
         A
       </th>
       <th
+        aria-hidden="true"
         className="label"
         id="col-label-2"
+        inert="true"
       >
         B
       </th>
@@ -529,8 +584,10 @@ exports[`PlayerTable component Rendered leftAligned, with header, with labels 1`
       id="row0"
     >
       <th
+        aria-hidden="true"
         className="label skinny"
         id="row-label-1"
+        inert="true"
       >
         1
       </th>
@@ -553,8 +610,10 @@ exports[`PlayerTable component Rendered leftAligned, with header, with labels 1`
       id="row1"
     >
       <td
+        aria-hidden="true"
         className="label skinny"
         id="row-label-2"
+        inert="true"
       >
         2
       </td>
@@ -563,6 +622,7 @@ exports[`PlayerTable component Rendered leftAligned, with header, with labels 1`
         id="cell2"
       >
         <input
+          aria-label="This cell is currently blank, please provide a value."
           autoComplete="off"
           className="unanswered"
           id="2-input"
@@ -615,6 +675,7 @@ exports[`PlayerTable component Rendered with randomness and a header 1`] = `
         id="cell2"
       >
         <input
+          aria-label="This cell is currently blank, please provide a value."
           autoComplete="off"
           className="unanswered"
           id="2-input"
@@ -658,6 +719,7 @@ exports[`PlayerTable component Rendered with randomness and no header 1`] = `
         id="cell1"
       >
         <input
+          aria-label="This cell is currently blank, please provide a value."
           autoComplete="off"
           className="unanswered"
           id="1-input"
@@ -677,6 +739,7 @@ exports[`PlayerTable component Rendered with randomness and no header 1`] = `
         id="cell2"
       >
         <input
+          aria-label="This cell is currently blank, please provide a value."
           autoComplete="off"
           className="unanswered"
           id="2-input"

--- a/src/components/player/__snapshots__/table.test.js.snap
+++ b/src/components/player/__snapshots__/table.test.js.snap
@@ -20,6 +20,7 @@ exports[`PlayerTable component Rendered centered, no header, no labels 1`] = `
         id="cell1"
       >
         <input
+          autoComplete="off"
           className="unanswered"
           id="1-input"
           onBlur={[Function]}
@@ -38,6 +39,7 @@ exports[`PlayerTable component Rendered centered, no header, no labels 1`] = `
         id="cell2"
       >
         <input
+          autoComplete="off"
           className="unanswered"
           id="2-input"
           onBlur={[Function]}
@@ -107,6 +109,7 @@ exports[`PlayerTable component Rendered centered, no header, with labels 1`] = `
         id="cell1"
       >
         <input
+          autoComplete="off"
           className="unanswered"
           id="1-input"
           onBlur={[Function]}
@@ -131,6 +134,7 @@ exports[`PlayerTable component Rendered centered, no header, with labels 1`] = `
         id="cell2"
       >
         <input
+          autoComplete="off"
           className="unanswered"
           id="2-input"
           onBlur={[Function]}
@@ -182,6 +186,7 @@ exports[`PlayerTable component Rendered centered, with header, no labels 1`] = `
         id="cell2"
       >
         <input
+          autoComplete="off"
           className="unanswered"
           id="2-input"
           onBlur={[Function]}
@@ -265,6 +270,7 @@ exports[`PlayerTable component Rendered centered, with header, with labels 1`] =
         id="cell2"
       >
         <input
+          autoComplete="off"
           className="unanswered"
           id="2-input"
           onBlur={[Function]}
@@ -307,6 +313,7 @@ exports[`PlayerTable component Rendered leftAligned, no header, no labels 1`] = 
         id="cell1"
       >
         <input
+          autoComplete="off"
           className="unanswered"
           id="1-input"
           onBlur={[Function]}
@@ -325,6 +332,7 @@ exports[`PlayerTable component Rendered leftAligned, no header, no labels 1`] = 
         id="cell2"
       >
         <input
+          autoComplete="off"
           className="unanswered"
           id="2-input"
           onBlur={[Function]}
@@ -394,6 +402,7 @@ exports[`PlayerTable component Rendered leftAligned, no header, with labels 1`] 
         id="cell1"
       >
         <input
+          autoComplete="off"
           className="unanswered"
           id="1-input"
           onBlur={[Function]}
@@ -418,6 +427,7 @@ exports[`PlayerTable component Rendered leftAligned, no header, with labels 1`] 
         id="cell2"
       >
         <input
+          autoComplete="off"
           className="unanswered"
           id="2-input"
           onBlur={[Function]}
@@ -469,6 +479,7 @@ exports[`PlayerTable component Rendered leftAligned, with header, no labels 1`] 
         id="cell2"
       >
         <input
+          autoComplete="off"
           className="unanswered"
           id="2-input"
           onBlur={[Function]}
@@ -552,6 +563,7 @@ exports[`PlayerTable component Rendered leftAligned, with header, with labels 1`
         id="cell2"
       >
         <input
+          autoComplete="off"
           className="unanswered"
           id="2-input"
           onBlur={[Function]}
@@ -603,6 +615,7 @@ exports[`PlayerTable component Rendered with randomness and a header 1`] = `
         id="cell2"
       >
         <input
+          autoComplete="off"
           className="unanswered"
           id="2-input"
           onBlur={[Function]}
@@ -645,6 +658,7 @@ exports[`PlayerTable component Rendered with randomness and no header 1`] = `
         id="cell1"
       >
         <input
+          autoComplete="off"
           className="unanswered"
           id="1-input"
           onBlur={[Function]}
@@ -663,6 +677,7 @@ exports[`PlayerTable component Rendered with randomness and no header 1`] = `
         id="cell2"
       >
         <input
+          autoComplete="off"
           className="unanswered"
           id="2-input"
           onBlur={[Function]}

--- a/src/components/player/cell.js
+++ b/src/components/player/cell.js
@@ -21,6 +21,9 @@ class Cell extends React.Component {
 			value = value.slice(0, 36);
 		}
 
+		// trigger the behavior to save the answer if we went from empty to non-empty or vice versa
+		if (!this.state.value.length || !value.length) this.props.saveAnswer(event);
+
 		this.setState({
 			value: value,
 			colorClass: this.state.colorClass,

--- a/src/components/player/cell.js
+++ b/src/components/player/cell.js
@@ -69,6 +69,7 @@ class Cell extends React.Component {
 				{ this.props.showInput ?
 					<input
 						type="text"
+						aria-label={this.state.value != '' ? 'Current cell value: ' + this.state.value : 'This cell is currently blank, please provide a value.'}
 						id={this.props.inputID}
 						value={this.state.value}
 						onChange={this.handleChange}

--- a/src/components/player/cell.js
+++ b/src/components/player/cell.js
@@ -59,9 +59,13 @@ class Cell extends React.Component {
 	}
 
 	render() {
+		// const cellClass = `${this.props.showInput ? `${this.state.colorClass} `:``}${this.props.leftAlign ? `leftAlign`:`centerAlign`}`
+		const cellClass = (this.props.showInput ? this.state.colorClass + ' ' : '') +
+			(this.props.leftAlign ? 'leftAlign' : 'centerAlign')
 		// test if it should display an input box or if it should show the text
 		return(
-			<td id={this.props.id} className={`${this.props.showInput ? `${this.state.colorClass} `:``}${this.props.leftAlign ? `leftAlign`:`centerAlign`}`} >
+			<td id={this.props.id}
+				className={cellClass} >
 				{ this.props.showInput ?
 					<input
 						type="text"
@@ -71,6 +75,7 @@ class Cell extends React.Component {
 						onBlur={this.props.saveAnswer}
 						className={this.state.colorClass}
 						ref={this.input}
+						autoComplete='off'
 						placeholder="?"
 					/>
 					: <span>{this.props.displayText}</span>

--- a/src/components/player/cell.test.js
+++ b/src/components/player/cell.test.js
@@ -239,4 +239,39 @@ describe(`Cell component`, () => {
 		// cleanup
 		tempComponent.unmount();
 	});
+
+	test('handleChange calls props.saveAnswer appropriately', () => {
+		const mockSaveAnswer = jest.fn();
+
+		const props = makeProps(true, false);
+		props.saveAnswer = mockSaveAnswer;
+
+		const tempComponent = shallow(<Cell {... props} />);
+
+		const event = {
+			target: { value: 'test' }
+		};
+
+		// changing from a blank answer to a non-blank answer should call saveAnswer
+		tempComponent.instance().handleChange(event);
+		expect(tempComponent.state([`value`])).toEqual('test');
+		expect(mockSaveAnswer).toHaveBeenCalledTimes(1);
+		mockSaveAnswer.mockClear();
+
+		// changing from a non-blank answer to a non-blank answer should not call save Answer
+		event.target.value = 'test2'
+		tempComponent.instance().handleChange(event);
+		expect(tempComponent.state([`value`])).toEqual('test2');
+		expect(mockSaveAnswer).not.toHaveBeenCalled();
+
+		// changing from a non-blank answer to a blank answer should call saveAnswer
+		event.target.value = ''
+		tempComponent.instance().handleChange(event);
+		expect(tempComponent.state([`value`])).toEqual('');
+		expect(mockSaveAnswer).toHaveBeenCalledTimes(1);
+		mockSaveAnswer.mockClear();
+
+		// cleanup
+		tempComponent.unmount();
+	})
 });

--- a/src/components/player/popup.js
+++ b/src/components/player/popup.js
@@ -1,21 +1,30 @@
 import React from 'react';
 
+const fullAriaString = "Secret Spreadsheet widget instructions. " +
+	"Cells of this spreadsheet have been intentionally hidden. " +
+	"Navigate the spreadsheet and input the hidden data until all cells have been filled. " +
+	"Capitalization and punctuation must be precise to match correctly. " +
+	"Navigate the table using your screen reader's dedicated key bindings, or use the tab key to move between blank cells."
+
 // popup containing instructions on how to use the wdget
 const Popup = props => {
-	return(
+	return (
 		<div className="popup help">
 			<div>
-				<h2>Secret Spreadsheet - How it works:</h2>
+				<h2 aria-label={fullAriaString}
+					tabIndex="0">
+					Secret Spreadsheet - How it works:
+				</h2>
 
 				<div>
 					<img src="assets/img/helper-pic.svg" alt="Secret Spreadsheet Instructions" />
-
 					<p>Cells of this spreadsheet have been <strong>intentionally hidden.</strong></p>
-
 					<p>Input the hidden data correctly <strong>(capitalization matters!)</strong> to restore the spreadsheet.</p>
 				</div>
 
-				<button type="button" value="Got it!" onClick={props.handlePopupToggle}>
+				<button type="button"
+					value="Got it!" onClick={props.handlePopupToggle}
+					tabIndex="0">
 					Got it!
 				</button>
 			</div>

--- a/src/components/player/popup.js
+++ b/src/components/player/popup.js
@@ -4,7 +4,7 @@ const fullAriaString = "Secret Spreadsheet widget instructions. " +
 	"Cells of this spreadsheet have been intentionally hidden. " +
 	"Navigate the spreadsheet and input the hidden data until all cells have been filled. " +
 	"Capitalization and punctuation must be precise to match correctly. " +
-	"Navigate the table using your screen reader's dedicated key bindings, or use the tab key to move between blank cells."
+	"Navigate the table cells individually using your screen reader's dedicated key bindings, or use the Tab key to move between blank cells."
 
 // popup containing instructions on how to use the wdget
 const Popup = props => {

--- a/src/components/player/question.js
+++ b/src/components/player/question.js
@@ -1,17 +1,41 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+
+const ariaWarningText = 'After closing this dialog focus will be automatically moved to the first empty cell in the spreadsheet.'
 
 // the popup containing the question and description given by the widget creator
 // at a minimum shows the question, description is optional
 const Question = props => {
+	const questionEl = useRef(null)
+
+	// bit of a hack to make sure the question is given focus when it comes up
+	useEffect(() => {
+		if (questionEl.current) questionEl.current.focus()
+	}, [])
+
 	return (
 		<div className="popup question">
 			<div>
-				<p className="mainQuestion">{props.question}</p>
+				<p className="mainQuestion"
+					tabIndex="0"
+					aria-label={`Question: ${props.question}: ${props.description}`}
+					ref={questionEl}>
+					{props.question}
+				</p>
 
-				{props.description !== `` ? <p>{props.description}</p>:null}
+				{
+					props.description !== ``
+					?
+						<p>{props.description}</p>
+					:
+						null
+				}
 
-				<button type="button" value="Next" onClick={props.handleQuestionToggle}>
-						Next
+				<button type="button"
+					value="Next"
+					onClick={props.handleQuestionToggle}
+					tabIndex="0"
+					aria-label={ariaWarningText}>
+					Next
 				</button>
 			</div>
 		</div>

--- a/src/components/player/question.test.js
+++ b/src/components/player/question.test.js
@@ -1,35 +1,77 @@
+jest.mock('react', () => {
+	const ActualReact = jest.requireActual('react')
+	return {
+		...ActualReact,
+		useRef: jest.fn()
+	}
+})
+
 import React from 'react';
 import Question from './question';
-import renderer from 'react-test-renderer';
+import { create, act } from 'react-test-renderer';
 
 describe(`Question component`, () => {
 	beforeEach(() => {
 		jest.resetModules();
+		React.useRef.mockClear();
 	});
 
 	test(`Is rendered with question body`, () => {
+		const mockFocus = jest.fn();
+		React.useRef.mockReturnValue({
+			current: {
+				focus: mockFocus
+			}
+		});
+
 		const props = {
 			handleQuestionToggle: jest.fn(),
 			question: `Test entry question`,
 			description: `Test question body`
 		};
 
-		const component = renderer.create(<Question {... props} />);
+		let component
+		act(() => {
+			component = create(<Question {... props} />, {
+				createNodeMock: () => ({
+					focus: mockFocus
+				})
+			});
+		})
 		const tree = component.toJSON();
 
 		expect(tree).toMatchSnapshot();
+
+		// bonus test - make sure the ref works and auto-focuses
+		expect(mockFocus).toHaveBeenCalled();
 	});
 
 	test(`Is rendered without question body`, () => {
+		const mockFocus = jest.fn();
+		React.useRef.mockReturnValue({
+			current: {
+				focus: mockFocus
+			}
+		});
+
 		const props = {
 			handleQuestionToggle: jest.fn(),
 			question: `Test entry question`,
 			description: ``
 		};
 
-		const component = renderer.create(<Question {... props} />);
+		// not sure if this is even possible, but...
+		// update the ref to null to make sure nothing calls 'focus'?
+		let component
+		act(() => {
+			component = create(<Question {... props} />, {
+				createNodeMock: () => null
+			});
+		})
 		const tree = component.toJSON();
 
 		expect(tree).toMatchSnapshot();
+
+		expect(mockFocus).not.toHaveBeenCalled();
 	});
 });

--- a/src/components/player/table.js
+++ b/src/components/player/table.js
@@ -72,20 +72,34 @@ class PlayerTable extends React.Component {
 
 			// add in the leftmost label (above the row labels)
 			cells.push(
-				<th key="col-label-0" id="col-label-0" className="label skinny" />
+				<th key="col-label-0"
+					id="col-label-0"
+					aria-hidden="true"
+					inert="true"
+					className="label skinny" />
 			);
 
 			for (let i=0;i<this.props.dimensions.columns;i++) {
 				const b26Number = this.convertNumberToLetters(i);
 
 				cells.push(
-					<th key={`col-label-${i+1}`} id={`col-label-${i+1}`} className="label">
+					<th key={`col-label-${i+1}`}
+						id={`col-label-${i+1}`}
+						aria-hidden="true"
+						inert="true"
+						className="label">
 						{b26Number}
 					</th>
 				);
 			}
 
-			headRows.push(<tr key="column-labels" id="column-labels">{cells}</tr>);
+			headRows.push(<tr key="column-labels"
+				aria-hidden="true"
+				inert="true"
+				id="column-labels">
+					{cells}
+				</tr>
+			);
 		}
 
 		// generate the table
@@ -104,14 +118,22 @@ class PlayerTable extends React.Component {
 					// make the first label generated a th if needed
 					if (i === 0 && this.props.header) {
 						cells.push(
-							<th key={`row-label-${i+1}`} id={`row-label-${i+1}`} className="label skinny" >
+							<th key={`row-label-${i+1}`}
+								id={`row-label-${i+1}`}
+								aria-hidden="true"
+								inert="true"
+								className="label skinny" >
 								{i+1}
 							</th>
 						);
 					}
 					else {
 						cells.push(
-							<td key={`row-label-${i+1}`} id={`row-label-${i+1}`} className="label skinny" >
+							<td key={`row-label-${i+1}`}
+								id={`row-label-${i+1}`}
+								aria-hidden="true"
+								inert="true"
+								className="label skinny" >
 								{i+1}
 							</td>
 						);
@@ -177,7 +199,7 @@ class PlayerTable extends React.Component {
 		}
 
 		return(
-			<table>
+			<table onFocus={() => {console.log('table got focus?')}}>
 				<thead>
 					{headRows}
 				</thead>

--- a/src/components/player/table.js
+++ b/src/components/player/table.js
@@ -199,7 +199,7 @@ class PlayerTable extends React.Component {
 		}
 
 		return(
-			<table onFocus={() => {console.log('table got focus?')}}>
+			<table>
 				<thead>
 					{headRows}
 				</thead>

--- a/src/install.yaml
+++ b/src/install.yaml
@@ -21,6 +21,8 @@ score:
   score_module: SecretSpreadsheet
   score_screen: scoreScreen.html
 meta_data:
+  accessibility_keyboard: Full
+  accessibility_reader: Full
   features:
     - Customizable
     - Scorable

--- a/src/player.js
+++ b/src/player.js
@@ -171,6 +171,7 @@ class PlayerApp extends React.Component {
 					:
 						<button type="button"
 							value="Help"
+							inert={this.state.showQuestion ? 'yes' : undefined}
 							onClick={this.handlePopupToggle}>
 							<img src="./assets/img/question-mark.svg" />
 							Help
@@ -189,7 +190,10 @@ class PlayerApp extends React.Component {
 						/>:
 						null}
 
-					<p className="instructions">Input the <span>missing data</span> to complete the spreadsheet:</p>
+					<p className="instructions"
+						inert="true">
+						Input the <span>missing data</span> to complete the spreadsheet:
+					</p>
 
 					<form onSubmit={this.handleSubmit}
 						inert={this.state.showQuestion || this.state.popup ? 'yes' : undefined}>
@@ -230,6 +234,13 @@ class PlayerApp extends React.Component {
 
 						<input type="submit"
 							value="Submit"
+							aria-label={ 'Submit answers.' +
+								(
+								this.state.answered !== this.blankPositions.size
+								? ` Warning, ${this.state.answered} of ${this.blankPositions.size} blank cells have been filled in.`
+								: ''
+								)
+							}
 							className={this.state.answered !== this.blankPositions.size ? `grayed`:`filled`}
 						/>
 					</form>

--- a/src/player.js
+++ b/src/player.js
@@ -22,6 +22,7 @@ class PlayerApp extends React.Component {
 		this.handlePopupToggle = this.handlePopupToggle.bind(this);
 		this.randomize = this.randomize.bind(this);
 		this.countBlanks = this.countBlanks.bind(this);
+		this.handleQuestionKeyUp = this.handleQuestionKeyUp.bind(this);
 		this.handleQuestionToggle = this.handleQuestionToggle.bind(this);
 	}
 
@@ -108,6 +109,11 @@ class PlayerApp extends React.Component {
 		}
 	}
 
+	// because the 'question' link isn't a button we have to handle space/enter presses on it ourselves
+	handleQuestionKeyUp(e) {
+		if (e.key === ' ' || e.key === 'Enter') this.handleQuestionToggle()
+	}
+
 	// decides if it should show the question popup or not
 	handleQuestionToggle() {
 		if (this.state.showQuestion) {
@@ -158,7 +164,18 @@ class PlayerApp extends React.Component {
 			<div>
 				<header>
 					<h1>{this.props.title}</h1>
-					{this.state.popup ? null:<button type="button" value="Help" onClick={this.handlePopupToggle}><img src="./assets/img/question-mark.svg" />Help</button>}
+					{
+					this.state.popup
+					?
+						null
+					:
+						<button type="button"
+							value="Help"
+							onClick={this.handlePopupToggle}>
+							<img src="./assets/img/question-mark.svg" />
+							Help
+						</button>
+					}
 				</header>
 
 				<main>
@@ -174,7 +191,8 @@ class PlayerApp extends React.Component {
 
 					<p className="instructions">Input the <span>missing data</span> to complete the spreadsheet:</p>
 
-					<form onSubmit={this.handleSubmit}>
+					<form onSubmit={this.handleSubmit}
+						inert={this.state.showQuestion || this.state.popup ? 'yes' : undefined}>
 						<div className="table-surround">
 							<div>
 								<PlayerTable
@@ -196,10 +214,21 @@ class PlayerApp extends React.Component {
 
 						<p>You've filled out {this.state.answered} of {this.blankPositions.size} missing cells</p>
 
-						{this.state.question ? <p className="link" onClick={this.handleQuestionToggle}>View Question</p>:null}
+						{
+							this.state.question
+							?
+								<p className="link"
+									onKeyUp={this.handleQuestionKeyUp}
+									onClick={this.handleQuestionToggle}
+									aria-roledescription='button'
+									tabIndex="0">
+									View Question
+								</p>
+							:
+								null
+						}
 
-						<input
-							type="submit"
+						<input type="submit"
 							value="Submit"
 							className={this.state.answered !== this.blankPositions.size ? `grayed`:`filled`}
 						/>

--- a/src/player.scss
+++ b/src/player.scss
@@ -170,6 +170,12 @@ header {
 	p:not(.mainQuestion) {
 		margin-bottom: 20px;
 	}
+
+	&:focus {
+		.mainQuestion {
+			text-decoration: underline;
+		}
+	}
 }
 
 .help {

--- a/src/player.scss
+++ b/src/player.scss
@@ -194,6 +194,7 @@ main {
 		border-radius: 3px;
 		font-size: inherit;
 		font-family: inherit;
+		cursor: pointer;
 	}
 }
 
@@ -234,13 +235,16 @@ form p {
 	background-color: #eff0ef;
 	border: none;
 	color: gray;
+
+	&:hover, &:focus {
+		background-color: #cacaca;
+	}
 }
 
 // button colors
 .filled {
 	background-color: #6f0cac;
 	color: white;
-	cursor: pointer;
 	border: none;
 
 	&:hover, &:focus {

--- a/src/player.test.js
+++ b/src/player.test.js
@@ -444,6 +444,36 @@ describe(`Player`, () => {
 		mockPlayer.unmount();
 	});
 
+	test('handleKeyUp does nothing when handling an irrelevant key', () => {
+		const mockPlayer = makeNewPlayer();
+
+		const mockHandleQuestionToggle = jest.fn();
+
+		mockPlayer.instance().handleQuestionToggle = mockHandleQuestionToggle;
+
+		const mockKeyupEvent = { key: 'Tab' };
+
+		mockPlayer.instance().handleQuestionKeyUp(mockKeyupEvent);
+		expect(mockHandleQuestionToggle).not.toHaveBeenCalled();
+	});
+	test('handleKeyUp handles expected keys', () => {
+		const mockPlayer = makeNewPlayer();
+
+		const mockHandleQuestionToggle = jest.fn();
+
+		mockPlayer.instance().handleQuestionToggle = mockHandleQuestionToggle;
+
+		let mockKeyupEvent;
+
+		mockKeyupEvent = { key: ' ' };
+		mockPlayer.instance().handleQuestionKeyUp(mockKeyupEvent);
+		expect(mockHandleQuestionToggle).toHaveBeenCalledTimes(1);
+
+		mockKeyupEvent = { key: 'Enter' };
+		mockPlayer.instance().handleQuestionKeyUp(mockKeyupEvent);
+		expect(mockHandleQuestionToggle).toHaveBeenCalledTimes(2);
+	});
+
 	test(`handleQuestionToggle is toggled off`, () => {
 		const mockPlayer = makeNewPlayer();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5503,10 +5503,10 @@ materia-server-client-assets@2.1.0:
     js-snakecase "^1.2.0"
     ngmodal ucfcdl/ngModal#v1.2.2
 
-materia-widget-development-kit@^2.4.2:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/materia-widget-development-kit/-/materia-widget-development-kit-2.5.0.tgz#0cc4d82854abf21286c18367cbede374529385b6"
-  integrity sha512-nvYBA/ZBm4SXpLWo6cccm0EDplmBAkcY4c9mjWCuY2BUwJvBgxvA33cKscYg0ktmI3dolPCYMXnb5CERx4239g==
+materia-widget-development-kit@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/materia-widget-development-kit/-/materia-widget-development-kit-2.5.2.tgz#831c7852bf2021cce8ed80a2b92d6153532b92f3"
+  integrity sha512-rth0CHtNm1R+5f1poDjHpx5iGzPTw9PjBexlp8KoBr/NaOFEPP8SCxZtBq2YltwRUcH3MOukLoa4k+566uTRXQ==
   dependencies:
     "@babel/core" "^7.4.5"
     "@babel/preset-env" "^7.4.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5897,7 +5897,7 @@ next-tick@~1.0.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
-"ngmodal@github:ucfcdl/ngModal#v1.2.2":
+ngmodal@ucfcdl/ngModal#v1.2.2:
   version "1.2.2"
   resolved "https://codeload.github.com/ucfcdl/ngModal/tar.gz/6abad982bdb8f258ffcdc20316a907c2292399d2"
 


### PR DESCRIPTION
Closes #27.
Added tab indices to numerous elements so they are reachable in the tab order.

Adjusted aria text for multiple elements and added modest visual effects to indicate when non-interactive elements have focus.

Added keyup handler on 'view question' link for keyboard support.

Disabled autocomplete on table inputs.

Added logic to toggle inert on the game board when a popup is visible.

**Additional fixes following review:**

Made the visible 'Input the missing data...' text inert so screen readers can't reach it at all.

Added an `aria-label` value to cell inputs to more verbosely indicate when a cell is blank and requires a value.

Made the 'Help' button inert while the question popup is active so it doesn't pollute the tab order.

Added a dynamic `aria-label` value to the submit button to indicate when not all blank cells have been given values.

Added `inert` and `aria-hidden` to the extra row and column added to the table in spreadsheet mode, allowing screen readers to count and navigate the usable table cells correctly.

Added a bit of logic to the cell component to save a cell's answer when changing a value if the current value or previous value were blank - essentially making sure the indicator for number of filled cells is always correct instead of just waiting to check when a cell loses focus.